### PR TITLE
Add process name in the error message for easy debug

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ async fn main() {
         match result {
             Ok(params) => env.params(&params),
             Err(error) => {
-                eprintln!("[ERROR] Reading parameters at `{}`: {}", path, error);
+                eprintln!("[PSE][ERROR] Reading parameters at `{}`: {}", path, error);
                 std::process::exit(1);
             }
         };


### PR DESCRIPTION
As different services log errors in the similar format `[Error]` it's hard to debug which service throws the error. 
Add the service name as a prefix for the error message. Example `[PSE][Error] This is an error`
